### PR TITLE
Add missing "type" parameter for userRepositories

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -139,6 +139,7 @@ class GitHub {
    */
   Stream<Repository> userRepositories(String user, {String type: "owner", String sort: "full_name", String direction: "asc"}) {
     var params = {
+      "type": type,
       "sort": sort,
       "direction": direction
     };


### PR DESCRIPTION
The "type" parameter was missing. See https://developer.github.com/v3/repos/#list-user-repositories
