### PR TITLE
Fixing scope OAuth 2 URL parameter

### DIFF
--- a/lib/src/common/util/oauth2.dart
+++ b/lib/src/common/util/oauth2.dart
@@ -48,7 +48,7 @@ class OAuth2Flow {
   String createAuthorizeUrl() {
     return baseUrl + "/authorize" + buildQueryString({
       "client_id": clientId,
-      "scopes": scopes.join(","),
+      "scope": scopes.join(","),
       "redirect_uri": redirectUri,
       "state": state
     });


### PR DESCRIPTION
"scopes" has no effect. "scope" is the correct URL parameter for GitHub's OAuth 2.0.

Fixes #45 
