### PR TITLE
Adjust deprecations and binary uploads

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -218,7 +218,7 @@ class GitHub {
   ///
   /// The future will pass the object returned from this function to the then method.
   /// The default [convert] function returns the input object.
-  /// [body] is the data to send to the server.
+  /// [body] is the data to send to the server. Pass in a List<int> if you want to post binary body data. Everything else will have .toString() called on it and set as text content
   /// [S] represents the input type.
   /// [T] represents the type return from this function after conversion
   Future<T> postJSON<S, T>(
@@ -291,7 +291,7 @@ class GitHub {
   /// [path] can either be a path like '/repos' or a full url.
   /// [headers] are HTTP Headers. If it doesn't exist, the 'Accept' and 'Authorization' headers are added.
   /// [params] are query string parameters.
-  /// [body] is the body content of requests that take content.
+  /// [body] is the body content of requests that take content. Pass in a List<int> if you want to post binary body data. Everything else will have .toString() called on it and set as text content
   ///
   Future<http.Response> request(
     String method,
@@ -344,10 +344,10 @@ class GitHub {
     var request = http.Request(method, Uri.parse(url.toString()));
     request.headers.addAll(headers);
     if (body != null) {
-      if (body is String) {
-        request.body = body;
-      } else {
+      if (body is List<int>) {
         request.bodyBytes = body;
+      } else {
+        request.body = body.toString();
       }
     }
 

--- a/lib/src/common/model/repos_releases.dart
+++ b/lib/src/common/model/repos_releases.dart
@@ -64,14 +64,30 @@ class Release {
   @JsonKey(name: "draft")
   bool isDraft;
 
+  /// Deprecated: Use isDraft instead
   @Deprecated('Use isDraft')
+  @JsonKey(ignore: true)
   bool get draft => isDraft;
 
+  /// Deprecated: Use isDraft instead
+  @Deprecated('Use isDraft')
+  @JsonKey(ignore: true)
+  set draft(bool b) => isDraft = b;
+
   /// If the release is a pre-release.
+  /// Deprecated: Use isPrerelease instead
   @Deprecated('Use isPrerelease')
+  @JsonKey(ignore: true)
   bool get prerelease => isPrerelease;
 
   /// If the release is a pre-release.
+  /// Deprecated: Use isPrerelease instead
+  @Deprecated('Use isPrerelease')
+  @JsonKey(ignore: true)
+  set prerelease(bool pr) => isPrerelease = pr;
+
+  /// If the release is a pre-release.
+  /// Deprecated: Use isPrerelease instead
   @JsonKey(name: "prerelease")
   bool isPrerelease;
 
@@ -184,16 +200,28 @@ class CreateRelease {
   /// Release Body
   String body;
 
+  /// Deprecated: Use isDraft instead
   @Deprecated('Use isDraft')
+  @JsonKey(ignore: true)
   bool get draft => isDraft;
+
+  /// Deprecated: Use isDraft instead
+  @Deprecated('Use isDraft')
+  @JsonKey(ignore: true)
+  set draft(bool d) => isDraft = d;
 
   /// If the release is a draft
   bool isDraft;
 
+  /// Deprecated: Use isPrerelease instead
   @Deprecated('Use isPrerelease')
+  @JsonKey(ignore: true)
   bool get prerelease => isPrerelease;
 
-  set prerelease(bool prerelease) => isPrerelease = prerelease;
+  /// Deprecated: Use isPrerelease instead
+  @Deprecated('Use isPrerelease')
+  @JsonKey(ignore: true)
+  set prerelease(bool pr) => isPrerelease = pr;
 
   /// true to identify the release as a prerelease.
   /// false to identify the release as a full release. Default: false

--- a/lib/src/common/model/repos_releases.g.dart
+++ b/lib/src/common/model/repos_releases.g.dart
@@ -52,8 +52,8 @@ Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
       'prerelease': instance.isPrerelease,
       'created_at': instance.createdAt?.toIso8601String(),
       'published_at': instance.publishedAt?.toIso8601String(),
-      'author': instance.author,
-      'assets': instance.assets,
+      'author': Release._authorToJson(instance.author),
+      'assets': Release._assetsToJson(instance.assets),
     };
 
 ReleaseAsset _$ReleaseAssetFromJson(Map<String, dynamic> json) {


### PR DESCRIPTION
@ThinkDigitalSoftware I made a couple of adjustments. Let me know what you think.

## Changes
- I filled out a little more information for the deprecations and ignored them for JSON serialization.
- I added some more information in the dartdoc comments for what you can pass in for the body of a request.
- I flipped the check when setting the body. It sets the body bytes if it is a List<int> and everything else is converted to a string and set as text content.

Would you be willing to give this a quick test for your use case to make sure it works for you?