### PR TITLE
Implement rate-limiting

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -290,6 +290,13 @@ class GitHub {
       int statusCode,
       void fail(http.Response response),
       String preview}) async {
+    if (rateLimitRemaining != null && rateLimitRemaining <= 0) {
+      assert(rateLimitReset != null);
+      var now = DateTime.now();
+      var waitTime = rateLimitReset.difference(now);
+      await Future.delayed(waitTime);
+    }
+
     if (headers == null) headers = {};
 
     if (preview != null) {


### PR DESCRIPTION
Rate limiting information was being gathered but never used to actually wait.

This change will wait until rate limit reset before sending a request to the GitHub API.