### PR TITLE
Back off when server fails (HTTP 50x)

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -391,6 +391,10 @@ class GitHub {
           }
         }
         throw ValidationFailed(this, buff.toString());
+      case 500:
+      case 502:
+      case 504:
+        throw ServerError(this, response.statusCode, message);
     }
     throw UnknownError(this, message);
   }

--- a/lib/src/common/util/errors.dart
+++ b/lib/src/common/util/errors.dart
@@ -60,6 +60,12 @@ class RateLimitHit extends GitHubError {
   RateLimitHit(GitHub github) : super(github, "Rate Limit Hit");
 }
 
+/// A GitHub Server Error
+class ServerError extends GitHubError {
+  ServerError(GitHub github, int statusCode, String message)
+      : super(github, "${message ?? 'Server Error'} ($statusCode)");
+}
+
 /// An Unknown Error
 class UnknownError extends GitHubError {
   UnknownError(GitHub github, [String message])


### PR DESCRIPTION
When the GitHub API replies with a server error (usually HTTP 502), retry up to `maxServerErrors` times with `serverErrorBackOff` intervals in between.

Currently, the inputs above are constants: each request will tolerate at most 10 errors and will wait 10 seconds between each attempt (this is _in addition_ to any rate limiting imposed by the GitHub API). If needed, it is easy enough to add both as optional arguments to `fetchStreamed`.

This is important for long-running batch jobs. Without this change, the package will just crash any time it encounters a GitHub HTTP 50x error (which are rare, but not unheard of), losing any pagination progress.