### PR TITLE
Make method createGitHubClient support vm flutter and web.

### DIFF
--- a/lib/github.dart
+++ b/lib/github.dart
@@ -1,0 +1,11 @@
+/// The code come from https://github.com/dart-lang/http/blob/9a17157e6a71972f929a95c6b2b36992e5e02c6d/lib/src/client.dart#L11-L16
+
+// ignore: uri_does_not_exist
+// ignore:
+export 'github_stub.dart'
+// ignore: uri_does_not_exist
+    if (dart.library.html) 'browser.dart'
+// ignore: uri_does_not_exist
+    if (dart.library.io) 'server.dart';
+
+export 'src/common.dart';

--- a/lib/github_stub.dart
+++ b/lib/github_stub.dart
@@ -1,0 +1,6 @@
+import 'src/common.dart';
+
+GitHub createGitHubClient(
+        {Authentication auth, String endpoint = "https://api.github.com"}) =>
+    throw UnsupportedError(
+        'Cannot create a client without dart:html or dart:io.');


### PR DESCRIPTION
Imitate the way http is written, let the createGitHubClient method work on dart vm, flutter and web.