### PR TITLE
make RepositoryContents json serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v6.0.1
+ - Fix https://github.com/SpinlockLabs/github.dart/issues/190
+
 ## v6.0.0
 
 - There's a single entrypoint now: `package:github/github.dart`

--- a/lib/src/common/model/repos_contents.dart
+++ b/lib/src/common/model/repos_contents.dart
@@ -87,12 +87,22 @@ class Links {
 }
 
 /// Model class for a file or directory.
+@JsonSerializable(fieldRename: FieldRename.snake)
 class RepositoryContents {
+  RepositoryContents({
+    this.file,
+    this.tree,
+  });
   GitHubFile file;
   List<GitHubFile> tree;
 
   bool get isFile => file != null;
   bool get isDirectory => tree != null;
+
+  factory RepositoryContents.fromJson(Map<String, dynamic> json) =>
+      _$RepositoryContentsFromJson(json);
+
+  Map<String, dynamic> toJson() => _$RepositoryContentsToJson(this);
 }
 
 /// Model class for a new file to be created.

--- a/lib/src/common/model/repos_contents.g.dart
+++ b/lib/src/common/model/repos_contents.g.dart
@@ -56,6 +56,24 @@ Map<String, dynamic> _$LinksToJson(Links instance) => <String, dynamic>{
       'html': instance.html?.toString(),
     };
 
+RepositoryContents _$RepositoryContentsFromJson(Map<String, dynamic> json) {
+  return RepositoryContents(
+    file: json['file'] == null
+        ? null
+        : GitHubFile.fromJson(json['file'] as Map<String, dynamic>),
+    tree: (json['tree'] as List)
+        ?.map((e) =>
+            e == null ? null : GitHubFile.fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+  );
+}
+
+Map<String, dynamic> _$RepositoryContentsToJson(RepositoryContents instance) =>
+    <String, dynamic>{
+      'file': instance.file,
+      'tree': instance.tree,
+    };
+
 CreateFile _$CreateFileFromJson(Map<String, dynamic> json) {
   return CreateFile(
     path: json['path'] as String,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 6.0.0
+version: 6.0.1
 author: Kenneth Endfinger <kaendfinger@gmail.com>
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart


### PR DESCRIPTION
Looks like a class was missed that wasn't made json serializable. I'm hoping this fixes https://github.com/SpinlockLabs/github.dart/issues/190
It should be converted either way.