### PR TITLE
Add content param to listReactions for issues

### DIFF
--- a/lib/src/common/github.dart
+++ b/lib/src/common/github.dart
@@ -352,7 +352,13 @@ class GitHub {
       final json = jsonDecode(response.body);
       message = json['message'];
       if (json['errors'] != null) {
-        errors = List<Map<String, String>>.from(json['errors']);
+        try {
+          errors = List<Map<String, String>>.from(json['errors']);
+        } catch (_) {
+          errors = [
+            {'code': json['errors'].toString()}
+          ];
+        }
       }
     }
     switch (response.statusCode) {

--- a/lib/src/common/issues_service.dart
+++ b/lib/src/common/issues_service.dart
@@ -130,6 +130,13 @@ class IssuesService extends Service {
     );
   }
 
+  /// Gets a stream of [Reaction]s for an issue. 
+  /// The optional content param let's you filter the request for only reactions
+  /// of that type. 
+  /// WARNING: ReactionType.plusOne and ReactionType.minusOne currently do not
+  /// work and will throw an exception is used. All others without + or - signs
+  /// work fine to filter.
+  /// 
   /// This API is currently in preview. It may break.
   ///
   /// See https://developer.github.com/v3/reactions/

--- a/lib/src/common/issues_service.dart
+++ b/lib/src/common/issues_service.dart
@@ -130,13 +130,13 @@ class IssuesService extends Service {
     );
   }
 
-  /// Gets a stream of [Reaction]s for an issue. 
+  /// Gets a stream of [Reaction]s for an issue.
   /// The optional content param let's you filter the request for only reactions
-  /// of that type. 
+  /// of that type.
   /// WARNING: ReactionType.plusOne and ReactionType.minusOne currently do not
   /// work and will throw an exception is used. All others without + or - signs
   /// work fine to filter.
-  /// 
+  ///
   /// This API is currently in preview. It may break.
   ///
   /// See https://developer.github.com/v3/reactions/

--- a/lib/src/common/issues_service.dart
+++ b/lib/src/common/issues_service.dart
@@ -133,15 +133,18 @@ class IssuesService extends Service {
   /// This API is currently in preview. It may break.
   ///
   /// See https://developer.github.com/v3/reactions/
-  Stream<Reaction> listReactions(RepositorySlug slug, int issueNumber) =>
-      PaginationHelper(github).objects(
-        'GET',
-        '/repos/${slug.owner}/${slug.name}/issues/$issueNumber/reactions',
-        (i) => Reaction.fromJson(i),
-        headers: {
-          'Accept': 'application/vnd.github.squirrel-girl-preview+json',
-        },
-      );
+  Stream<Reaction> listReactions(RepositorySlug slug, int issueNumber,
+      {ReactionType content}) {
+    var query = content != null ? '?content=${content.content}' : '';
+    return PaginationHelper(github).objects(
+      'GET',
+      '/repos/${slug.owner}/${slug.name}/issues/$issueNumber/reactions$query',
+      (i) => Reaction.fromJson(i),
+      headers: {
+        'Accept': 'application/vnd.github.squirrel-girl-preview+json',
+      },
+    );
+  }
 
   /// Edit an issue.
   ///

--- a/lib/src/common/model/reaction.dart
+++ b/lib/src/common/model/reaction.dart
@@ -1,6 +1,7 @@
 import 'package:github/src/common.dart';
 import 'package:github/src/common/model/users.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'reaction.g.dart';
 
@@ -23,8 +24,50 @@ class Reaction {
     this.createdAt,
   });
 
+  ReactionType get type => ReactionType.fromString(content);
+
   factory Reaction.fromJson(Map<String, dynamic> json) =>
       _$ReactionFromJson(json);
 
   Map<String, dynamic> toJson() => _$ReactionToJson(this);
+}
+
+@immutable
+class ReactionType {
+  final String content;
+  final String emoji;
+  const ReactionType._(this.content, this.emoji);
+
+  @override
+  String toString() => content;
+
+  static const plusOne = ReactionType._('+1', '👍');
+  static const minusOne = ReactionType._('-1', '👎');
+  static const laugh = ReactionType._('laugh', '😄');
+  static const confused = ReactionType._('confused', '😕');
+  static const heart = ReactionType._('heart', '❤️');
+  static const hooray = ReactionType._('hooray', '🎉');
+  static const rocket = ReactionType._('rocket', '🚀');
+  static const eyes = ReactionType._('eyes', '👀');
+
+  static final _types = {
+    '+1': plusOne,
+    '-1': minusOne,
+    'laugh': laugh,
+    'confused': confused,
+    'heart': heart,
+    'hooray': hooray,
+    'rocket': rocket,
+    'eyes': eyes,
+    ':+1:': plusOne,
+    ':-1:': minusOne,
+    ':laugh:': laugh,
+    ':confused:': confused,
+    ':heart:': heart,
+    ':hooray:': hooray,
+    ':rocket:': rocket,
+    ':eyes:': eyes,
+  };
+
+  static ReactionType fromString(String content) => _types[content];
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,7 +15,8 @@ String buildQueryString(Map<String, dynamic> params) {
     if (params[key] == null) {
       continue;
     }
-    queryString.write('$key=${Uri.encodeComponent(params[key].toString())}');
+    queryString
+        .write('$key=${Uri.encodeQueryComponent(params[key].toString())}');
     if (i != params.keys.length) {
       queryString.write('&');
     }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -15,8 +15,7 @@ String buildQueryString(Map<String, dynamic> params) {
     if (params[key] == null) {
       continue;
     }
-    queryString
-        .write('$key=${Uri.encodeQueryComponent(params[key].toString())}');
+    queryString.write('$key=${Uri.encodeComponent(params[key].toString())}');
     if (i != params.keys.length) {
       queryString.write('&');
     }

--- a/test/experiment/reactions.dart
+++ b/test/experiment/reactions.dart
@@ -1,0 +1,11 @@
+import 'package:github/github.dart';
+
+void main() {
+  final github = GitHub(auth: findAuthenticationFromEnvironment());
+  github.issues
+      .listReactions(RepositorySlug('SpinlockLabs', 'github.dart'), 177,
+          content: ReactionType.plusOne)
+      .listen((Reaction r) {
+    print(ReactionType.fromString(r.content).emoji);
+  });
+}


### PR DESCRIPTION
# Overview
According to https://developer.github.com/v3/reactions/#list-reactions-for-an-issue it can take an optional `content` parameter to filter reactions by that reaction. This PR adds that capability.

Strangely, it works for all reactions except for +1 and -1. I assume due to the URL encoding of the + and - signs. I've tried multiple different ways of encoding and the github API always seems to fail with `Variable $content of type ReactionContent was provided invalid value`. At this point, I'm wondering if there's a decoding issue on github's side for this API.

Tried:
```
curl --header "Accept:application/vnd.github.squirrel-girl-preview+json"  https://api.github.com/repos/SpinlockLabs/github.dart/issues/177/reactions\?content\=+1
curl --header "Accept:application/vnd.github.squirrel-girl-preview+json"  https://api.github.com/repos/SpinlockLabs/github.dart/issues/177/reactions\?content\=\%2B1
curl --header "Accept:application/vnd.github.squirrel-girl-preview+json"  https://api.github.com/repos/SpinlockLabs/github.dart/issues/177/reactions\?content\=%2B1
```

FYI @kevmoo