### PR TITLE
Add support for creating draft PRs

### DIFF
--- a/lib/src/common/model/pulls.dart
+++ b/lib/src/common/model/pulls.dart
@@ -1,6 +1,7 @@
 import 'package:github/src/common.dart';
 import 'package:github/src/common/model/users.dart';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:meta/meta.dart';
 
 part 'pulls.g.dart';
 
@@ -159,11 +160,20 @@ class PullRequestHead {
 /// Model class for a pull request to be created.
 @JsonSerializable(fieldRename: FieldRename.snake)
 class CreatePullRequest {
-  CreatePullRequest(this.title, this.head, this.base, {this.body});
+  CreatePullRequest(this.title, this.head, this.base,
+      {this.draft = false, this.body});
 
   final String title;
   final String head;
   final String base;
+
+  /// Whether a draft PR should be created.
+  ///
+  /// This is currently experimental functionality since the way draft PRs are
+  /// created through Github's REST API is in developer preview only - and could change at any time.
+  @experimental
+  final bool draft;
+
   String body;
 
   factory CreatePullRequest.fromJson(Map<String, dynamic> input) =>

--- a/lib/src/common/model/pulls.g.dart
+++ b/lib/src/common/model/pulls.g.dart
@@ -129,6 +129,7 @@ CreatePullRequest _$CreatePullRequestFromJson(Map<String, dynamic> json) {
     json['title'] as String,
     json['head'] as String,
     json['base'] as String,
+    draft: json['draft'] as bool,
     body: json['body'] as String,
   );
 }
@@ -138,6 +139,7 @@ Map<String, dynamic> _$CreatePullRequestToJson(CreatePullRequest instance) =>
       'title': instance.title,
       'head': instance.head,
       'base': instance.base,
+      'draft': instance.draft,
       'body': instance.body,
     };
 

--- a/lib/src/common/pulls_service.dart
+++ b/lib/src/common/pulls_service.dart
@@ -49,8 +49,14 @@ class PullRequestsService extends Service {
   ///
   /// API docs: https://developer.github.com/v3/pulls/#create-a-pull-request
   Future<PullRequest> create(RepositorySlug slug, CreatePullRequest request) {
-    return github.postJSON('/repos/${slug.fullName}/pulls',
-        convert: (i) => PullRequest.fromJson(i), body: jsonEncode(request));
+    return github.postJSON(
+      '/repos/${slug.fullName}/pulls',
+      convert: (i) => PullRequest.fromJson(i),
+      body: jsonEncode(request),
+      preview: request.draft
+          ? 'application/vnd.github.shadow-cat-preview+json'
+          : null,
+    );
   }
 
   /// Edit a pull request.


### PR DESCRIPTION
In order to create a draft PR using Github's REST API, you have to add a special header:

```
application/vnd.github.shadow-cat-preview+json
```

To facilitate this, I added a new bool field to the `CreatePullRequest` class, and when it is true, the call made by `PullRequestService.create` updates the value of `preview` accordingly.

FYA @robbecker-wf 