### PR TITLE
Patch [pulls_service.create]

### DIFF
--- a/lib/src/common/pulls_service.dart
+++ b/lib/src/common/pulls_service.dart
@@ -53,9 +53,8 @@ class PullRequestsService extends Service {
       '/repos/${slug.fullName}/pulls',
       convert: (i) => PullRequest.fromJson(i),
       body: GitHubJson.encode(request),
-      preview: request.draft
-          ? 'application/vnd.github.shadow-cat-preview+json'
-          : null,
+      preview: 'application/vnd.github.sailor-v-preview+json',
+      statusCode: StatusCodes.CREATED,
     );
   }
 


### PR DESCRIPTION
This PR adds an expected status code for the method `create` in `pulls_service`.
Without it, the method silently fails, i.e. a `PullRequest` object is returned with all values set to null...

Also, this PR changes the preview header for this method (the previous one was obsolete).