### PR TITLE
Switch to dedicated rate_limit endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.1.0
+  - `RateLimit` queries `/rate_limit` and no longer uses quota
+
 ## 8.0.1
   - Minor tweaks to improve pub score
 

--- a/lib/src/common/misc_service.dart
+++ b/lib/src/common/misc_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'package:github/src/common.dart';
 
 /// The [MiscService] handles communication with misc related methods of the
@@ -61,8 +62,8 @@ class MiscService extends Service {
   ///
   /// API docs: https://developer.github.com/v3/rate_limit/
   Future<RateLimit> getRateLimit() {
-    return github.request('GET', '/').then((response) {
-      return RateLimit.fromHeaders(response.headers);
+    return github.request('GET', '/rate_limit').then((response) {
+      return RateLimit.fromRateLimitResponse(jsonDecode(response.body));
     });
   }
 

--- a/lib/src/common/model/misc.dart
+++ b/lib/src/common/model/misc.dart
@@ -39,6 +39,17 @@ class RateLimit {
     return RateLimit(limit, remaining, resets);
   }
 
+  /// Construct [RateLimit] from JSON response of /rate_limit.
+  ///
+  /// API docs: https://developer.github.com/v3/rate_limit/
+  factory RateLimit.fromRateLimitResponse(Map<String, dynamic> response) {
+    final rateJson = response['rate'] as Map<String, dynamic>;
+    final limit = int.parse(rateJson['limit']!);
+    final remaining = int.parse(rateJson['remaining']!);
+    final resets = DateTime.fromMillisecondsSinceEpoch(rateJson['reset']!);
+    return RateLimit(limit, remaining, resets);
+  }
+
   factory RateLimit.fromJson(Map<String, dynamic> input) =>
       _$RateLimitFromJson(input);
   Map<String, dynamic> toJson() => _$RateLimitToJson(this);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.0.1
+version: 8.1.0
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 


### PR DESCRIPTION
Querying `/` uses quota to find the rate limit. Moving to `/rate_limit` does not use quota.