### PR TITLE
Fix getRateLimit json double casting ints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.1.2
+ - Fixes `RateLimit.fromRateLimitResponse` to not double cast int
+
 ## 8.1.1
   - Fix up examples and license file https://github.com/SpinlockLabs/github.dart/pull/255 https://github.com/SpinlockLabs/github.dart/pull/254 https://github.com/SpinlockLabs/github.dart/pull/253
 

--- a/lib/src/common/model/misc.dart
+++ b/lib/src/common/model/misc.dart
@@ -44,8 +44,8 @@ class RateLimit {
   /// API docs: https://developer.github.com/v3/rate_limit/
   factory RateLimit.fromRateLimitResponse(Map<String, dynamic> response) {
     final rateJson = response['rate'] as Map<String, dynamic>;
-    final limit = int.parse(rateJson['limit']!);
-    final remaining = int.parse(rateJson['remaining']!);
+    final limit = rateJson['limit'] as int?;
+    final remaining = rateJson['remaining'] as int?;
     final resets = DateTime.fromMillisecondsSinceEpoch(rateJson['reset']!);
     return RateLimit(limit, remaining, resets);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.1.1
+version: 8.1.2
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/test/unit/common/model/misc_test.dart
+++ b/test/unit/common/model/misc_test.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+import 'package:github/src/common/model/misc.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('RateLimit', () {
+    test('fromRateLimitResponse', () {
+      // This is a truncated version of the response
+      const rateLimitJson = '''{
+        "resources": {
+          "rate": {
+            "limit": 5000,
+            "remaining": 4999,
+            "reset": 1372700873,
+            "used": 1
+          }
+      }''';
+      final rateLimit = RateLimit.fromRateLimitResponse(jsonDecode(rateLimitJson));
+
+      expect(rateLimit.limit, 5000);
+      expect(rateLimit.remaining, 4999);
+      expect(rateLimit.resets, DateTime.fromMillisecondsSinceEpoch(1372700873));
+    });
+  });
+}


### PR DESCRIPTION
I noticed this as my dependency finally migrated to null safety. The issue was double casting ints caused a type error.

Fixes https://github.com/flutter/flutter/issues/90475

I added a test with a response from github