### PR TITLE
Add: Auto release notes & generateReleaseNotes API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.2.3
+- Added `generateReleaseNotes` boolean to CreateRelase class to have github auto-create release notes
+- Added `generateReleaseNotes` method to RepositoriesService to have github create release notes
+  between to tags (without creating a release) and return the name and body. This is helpful when you want to add the release notes to a CHANGELOG.md before making the actual release
 ## 8.2.2
 - Up minimum json_serializable to ^6.0.0, json_annotation to ^4.3.0
 - Cleanup and regenerate generated files

--- a/lib/src/common/model/repos_releases.dart
+++ b/lib/src/common/model/repos_releases.dart
@@ -173,16 +173,21 @@ class CreateRelease {
   @JsonKey(name: 'prerelease')
   bool? isPrerelease;
 
+  String? discussionCategoryName;
+
+  bool generateReleaseNotes = false;
+
   CreateRelease(this.tagName);
 
-  CreateRelease.from({
-    required this.tagName,
-    required this.name,
-    required this.targetCommitish,
-    required this.isDraft,
-    required this.isPrerelease,
-    this.body,
-  });
+  CreateRelease.from(
+      {required this.tagName,
+      required this.name,
+      required this.targetCommitish,
+      required this.isDraft,
+      required this.isPrerelease,
+      this.body,
+      this.discussionCategoryName,
+      this.generateReleaseNotes = false});
 
   @override
   bool operator ==(Object other) =>
@@ -194,7 +199,9 @@ class CreateRelease {
           name == other.name &&
           body == other.body &&
           isDraft == other.isDraft &&
-          isPrerelease == other.isPrerelease;
+          isPrerelease == other.isPrerelease &&
+          generateReleaseNotes == other.generateReleaseNotes &&
+          discussionCategoryName == other.discussionCategoryName;
 
   @override
   int get hashCode =>
@@ -203,7 +210,9 @@ class CreateRelease {
       name.hashCode ^
       body.hashCode ^
       isDraft.hashCode ^
-      isPrerelease.hashCode;
+      isPrerelease.hashCode ^
+      discussionCategoryName.hashCode ^
+      generateReleaseNotes.hashCode;
 
   factory CreateRelease.fromJson(Map<String, dynamic> input) =>
       _$CreateReleaseFromJson(input);
@@ -235,4 +244,33 @@ class CreateReleaseAsset {
   ///
   /// GitHub expects the asset data in its raw binary form, rather than JSON.
   Uint8List assetData;
+}
+
+/// Holds release notes information
+@JsonSerializable()
+class ReleaseNotes {
+  ReleaseNotes(this.name, this.body);
+  String name;
+  String body;
+
+  factory ReleaseNotes.fromJson(Map<String, dynamic> input) =>
+      _$ReleaseNotesFromJson(input);
+  Map<String, dynamic> toJson() => _$ReleaseNotesToJson(this);
+}
+
+@JsonSerializable()
+class CreateReleaseNotes {
+  CreateReleaseNotes(this.owner, this.repo, this.tagName,
+      {this.targetCommitish, this.previousTagName, this.configurationFilePath});
+
+  String owner;
+  String repo;
+  String tagName;
+  String? targetCommitish;
+  String? previousTagName;
+  String? configurationFilePath;
+
+  factory CreateReleaseNotes.fromJson(Map<String, dynamic> input) =>
+      _$CreateReleaseNotesFromJson(input);
+  Map<String, dynamic> toJson() => _$CreateReleaseNotesToJson(this);
 }

--- a/lib/src/common/model/repos_releases.g.dart
+++ b/lib/src/common/model/repos_releases.g.dart
@@ -99,7 +99,9 @@ CreateRelease _$CreateReleaseFromJson(Map<String, dynamic> json) =>
       ..name = json['name'] as String?
       ..body = json['body'] as String?
       ..isDraft = json['draft'] as bool?
-      ..isPrerelease = json['prerelease'] as bool?;
+      ..isPrerelease = json['prerelease'] as bool?
+      ..discussionCategoryName = json['discussion_category_name'] as String?
+      ..generateReleaseNotes = json['generate_release_notes'] as bool;
 
 Map<String, dynamic> _$CreateReleaseToJson(CreateRelease instance) =>
     <String, dynamic>{
@@ -109,4 +111,37 @@ Map<String, dynamic> _$CreateReleaseToJson(CreateRelease instance) =>
       'body': instance.body,
       'draft': instance.isDraft,
       'prerelease': instance.isPrerelease,
+      'discussion_category_name': instance.discussionCategoryName,
+      'generate_release_notes': instance.generateReleaseNotes,
+    };
+
+ReleaseNotes _$ReleaseNotesFromJson(Map<String, dynamic> json) => ReleaseNotes(
+      json['name'] as String,
+      json['body'] as String,
+    );
+
+Map<String, dynamic> _$ReleaseNotesToJson(ReleaseNotes instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'body': instance.body,
+    };
+
+CreateReleaseNotes _$CreateReleaseNotesFromJson(Map<String, dynamic> json) =>
+    CreateReleaseNotes(
+      json['owner'] as String,
+      json['repo'] as String,
+      json['tag_name'] as String,
+      targetCommitish: json['target_commitish'] as String?,
+      previousTagName: json['previous_tag_name'] as String?,
+      configurationFilePath: json['configuration_file_path'] as String?,
+    );
+
+Map<String, dynamic> _$CreateReleaseNotesToJson(CreateReleaseNotes instance) =>
+    <String, dynamic>{
+      'owner': instance.owner,
+      'repo': instance.repo,
+      'tag_name': instance.tagName,
+      'target_commitish': instance.targetCommitish,
+      'previous_tag_name': instance.previousTagName,
+      'configuration_file_path': instance.configurationFilePath,
     };

--- a/lib/src/common/repos_service.dart
+++ b/lib/src/common/repos_service.dart
@@ -1276,4 +1276,20 @@ class RepositoriesService extends Service {
       statusCode: StatusCodes.OK,
     );
   }
+
+  /// Generate a name and body describing a release. The body content will be
+  /// markdown formatted and contain information like the changes since last
+  /// release and users who contributed. The generated release notes are not
+  /// saved anywhere. They are intended to be generated and used when
+  /// creating a new release.
+  ///
+  /// API docs: https://docs.github.com/en/rest/reference/repos#generate-release-notes-content-for-a-release
+  Future<ReleaseNotes> generateReleaseNotes(CreateReleaseNotes crn) async {
+    return github.postJSON<Map<String, dynamic>, ReleaseNotes>(
+      '/repos/${crn.owner}/${crn.repo}/releases/generate-notes',
+      body: GitHubJson.encode(crn),
+      statusCode: StatusCodes.OK,
+      convert: (i) => ReleaseNotes.fromJson(i),
+    );
+  }
 }

--- a/lib/src/server/hooks.dart
+++ b/lib/src/server/hooks.dart
@@ -98,7 +98,8 @@ class CheckRunEvent extends HookEvent {
     this.repository,
   });
 
-  factory CheckRunEvent.fromJson(Map<String, dynamic> input) => _$CheckRunEventFromJson(input);
+  factory CheckRunEvent.fromJson(Map<String, dynamic> input) =>
+      _$CheckRunEventFromJson(input);
   CheckRun? checkRun;
   String? action;
   User? sender;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.2.2
+version: 8.2.3
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/test/server/hooks_test.dart
+++ b/test/server/hooks_test.dart
@@ -8,8 +8,8 @@ import 'hooks_test_data.dart';
 void main() {
   group('CheckSuiteEvent', () {
     test('deserialize', () async {
-      final checkSuiteEvent =
-          CheckSuiteEvent.fromJson(json.decode(checkSuiteString) as Map<String, dynamic>);
+      final checkSuiteEvent = CheckSuiteEvent.fromJson(
+          json.decode(checkSuiteString) as Map<String, dynamic>);
       // Top level properties.
       expect(checkSuiteEvent.action, 'requested');
       expect(checkSuiteEvent.checkSuite, isA<CheckSuite>());
@@ -22,7 +22,8 @@ void main() {
   });
   group('CheckRunEvent', () {
     test('deserialize', () async {
-      final checkRunEvent = CheckRunEvent.fromJson(json.decode(checkRunString) as Map<String, dynamic>);
+      final checkRunEvent = CheckRunEvent.fromJson(
+          json.decode(checkRunString) as Map<String, dynamic>);
       // Top level properties.
       expect(checkRunEvent.action, 'created');
       expect(checkRunEvent.checkRun, isA<CheckRun>());


### PR DESCRIPTION
- Added `generateReleaseNotes` boolean to CreateRelase class to have github auto-create release notes
- Added `generateReleaseNotes` method to RepositoriesService to have github create release notes
  between to tags (without creating a release) and return the name and body. This is helpful when you want to add the release notes to a CHANGELOG.md before making the actual release
