### PR TITLE
Make CheckRunConclusion nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.2.4
+- Make CheckRunConclusion nullable
+
 ## 8.2.3
 - Added `generateReleaseNotes` boolean to CreateRelase class to have github auto-create release notes
 - Added `generateReleaseNotes` method to RepositoriesService to have github create release notes

--- a/lib/src/common/model/checks.dart
+++ b/lib/src/common/model/checks.dart
@@ -45,10 +45,14 @@ class CheckRunConclusion extends EnumWithValue {
   static const cancelled = CheckRunConclusion._('cancelled');
   static const timedOut = CheckRunConclusion._('timed_out');
   static const actionRequired = CheckRunConclusion._('action_required');
+  static const empty = CheckRunConclusion._(null);
 
-  const CheckRunConclusion._(String value) : super(value);
+  const CheckRunConclusion._(String? value) : super(value);
 
   factory CheckRunConclusion._fromValue(String? value) {
+    if (value == null) {
+      return empty;
+    }
     for (final level in const [
       success,
       failure,

--- a/lib/src/common/util/utils.dart
+++ b/lib/src/common/util/utils.dart
@@ -5,17 +5,17 @@ import 'package:meta/meta.dart';
 /// but with a String value that is used for serialization.
 @immutable
 abstract class EnumWithValue {
-  final String value;
+  final String? value;
 
   /// The value will be used when [toJson] or [toString] will be called.
   /// It will also be used to check if two [EnumWithValue] are equal.
   const EnumWithValue(this.value);
 
   @override
-  String toString() => value;
+  String toString() => value ?? 'null';
 
   /// Returns the String value of this.
-  String toJson() => value;
+  String toJson() => value ?? 'null';
 
   /// True iff [other] is an [EnumWithValue] with the same value as this object.
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.2.3
+version: 8.2.4
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 


### PR DESCRIPTION
This value is null until check run is complete (so you're supposed to rely on the status if this is null)

Fixes https://github.com/SpinlockLabs/github.dart/issues/277