### PR TITLE
Add files field in Git commit comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.2.6
+## 8.3.0
 - Support `files` field in class `GitHubComparison`
 
 ## 8.2.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 8.2.6
+- Support `files` field in class `GitHubComparison`
+
 ## 8.2.5
 - no library code changes
 - Add auto pub publish on new releases

--- a/lib/src/common/model/repos.dart
+++ b/lib/src/common/model/repos.dart
@@ -14,8 +14,8 @@ class GitHubComparison {
   final int? totalCommits;
   final List<CommitFile>? files;
 
-  GitHubComparison(
-      this.url, this.status, this.aheadBy, this.behindBy, this.totalCommits, this.files);
+  GitHubComparison(this.url, this.status, this.aheadBy, this.behindBy,
+      this.totalCommits, this.files);
 
   factory GitHubComparison.fromJson(Map<String, dynamic> json) =>
       _$GitHubComparisonFromJson(json);

--- a/lib/src/common/model/repos.dart
+++ b/lib/src/common/model/repos.dart
@@ -12,9 +12,10 @@ class GitHubComparison {
   final int? aheadBy;
   final int? behindBy;
   final int? totalCommits;
+  final List<CommitFile>? files;
 
   GitHubComparison(
-      this.url, this.status, this.aheadBy, this.behindBy, this.totalCommits);
+      this.url, this.status, this.aheadBy, this.behindBy, this.totalCommits, this.files);
 
   factory GitHubComparison.fromJson(Map<String, dynamic> json) =>
       _$GitHubComparisonFromJson(json);

--- a/lib/src/common/model/repos.g.dart
+++ b/lib/src/common/model/repos.g.dart
@@ -13,6 +13,9 @@ GitHubComparison _$GitHubComparisonFromJson(Map<String, dynamic> json) =>
       json['ahead_by'] as int?,
       json['behind_by'] as int?,
       json['total_commits'] as int?,
+      (json['files'] as List<dynamic>?)
+          ?.map((e) => CommitFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.2.6
+version: 8.3.0
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 8.2.5
+version: 8.2.6
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/test/src/mocks.mocks.dart
+++ b/test/src/mocks.mocks.dart
@@ -14,7 +14,6 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: implementation_imports
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 // ignore_for_file: prefer_const_constructors
-// ignore_for_file: unnecessary_overrides
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 


### PR DESCRIPTION
This is to support https://github.com/SpinlockLabs/github.dart/issues/283 by adding the files field in GitHubComparison.

https://docs.github.com/en/rest/reference/commits#compare-two-commits