### PR TITLE
Fix getting gists

### DIFF
--- a/lib/src/common/model/gists.dart
+++ b/lib/src/common/model/gists.dart
@@ -47,6 +47,7 @@ class Gist {
   DateTime? updatedAt;
 
   factory Gist.fromJson(Map<String, dynamic> input) => _$GistFromJson(input);
+  Map<String, dynamic> toJson() => _$GistToJson(this);
 }
 
 /// Model class for a gist file.
@@ -90,6 +91,7 @@ class GistFork {
 
   factory GistFork.fromJson(Map<String, dynamic> input) =>
       _$GistForkFromJson(input);
+  Map<String, dynamic> toJson() => _$GistForkToJson(this);
 }
 
 /// Model class for a gits history entry.
@@ -121,6 +123,7 @@ class GistHistoryEntry {
 
   factory GistHistoryEntry.fromJson(Map<String, dynamic> input) =>
       _$GistHistoryEntryFromJson(input);
+  Map<String, dynamic> toJson() => _$GistHistoryEntryToJson(this);
 }
 
 /// Model class for gist comments.

--- a/lib/src/common/model/gists.dart
+++ b/lib/src/common/model/gists.dart
@@ -5,7 +5,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'gists.g.dart';
 
 /// Model class for gists.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Gist {
   Gist({
     this.id,
@@ -26,7 +26,7 @@ class Gist {
   bool? public;
   User? owner;
   User? user;
-  List<GistFile>? files;
+  Map<String, GistFile>? files;
 
   @JsonKey(name: 'html_url')
   String? htmlUrl;
@@ -50,10 +50,10 @@ class Gist {
 }
 
 /// Model class for a gist file.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class GistFile {
   GistFile({
-    this.name,
+    this.filename,
     this.size,
     this.rawUrl,
     this.type,
@@ -61,10 +61,9 @@ class GistFile {
     this.truncated,
     this.content,
   });
-  String? name;
-  int? size;
 
-  @JsonKey(name: 'raw_url')
+  String? filename;
+  int? size;
   String? rawUrl;
   String? type;
   String? language;
@@ -73,10 +72,11 @@ class GistFile {
 
   factory GistFile.fromJson(Map<String, dynamic> input) =>
       _$GistFileFromJson(input);
+  Map<String, dynamic> toJson() => _$GistFileToJson(this);
 }
 
 /// Model class for a gist fork.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class GistFork {
   GistFork({this.user, this.id, this.createdAt, this.updatedAt});
   User? user;
@@ -93,7 +93,7 @@ class GistFork {
 }
 
 /// Model class for a gits history entry.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class GistHistoryEntry {
   GistHistoryEntry({
     this.version,

--- a/lib/src/common/model/gists.g.dart
+++ b/lib/src/common/model/gists.g.dart
@@ -16,9 +16,9 @@ Gist _$GistFromJson(Map<String, dynamic> json) => Gist(
       user: json['user'] == null
           ? null
           : User.fromJson(json['user'] as Map<String, dynamic>),
-      files: (json['files'] as List<dynamic>?)
-          ?.map((e) => GistFile.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      files: (json['files'] as Map<String, dynamic>?)?.map(
+        (k, e) => MapEntry(k, GistFile.fromJson(e as Map<String, dynamic>)),
+      ),
       htmlUrl: json['html_url'] as String?,
       commentsCount: json['comments'] as int?,
       gitPullUrl: json['git_pull_url'] as String?,
@@ -31,8 +31,23 @@ Gist _$GistFromJson(Map<String, dynamic> json) => Gist(
           : DateTime.parse(json['updated_at'] as String),
     );
 
+Map<String, dynamic> _$GistToJson(Gist instance) => <String, dynamic>{
+      'id': instance.id,
+      'description': instance.description,
+      'public': instance.public,
+      'owner': instance.owner,
+      'user': instance.user,
+      'files': instance.files,
+      'html_url': instance.htmlUrl,
+      'comments': instance.commentsCount,
+      'git_pull_url': instance.gitPullUrl,
+      'git_push_url': instance.gitPushUrl,
+      'created_at': instance.createdAt?.toIso8601String(),
+      'updated_at': instance.updatedAt?.toIso8601String(),
+    };
+
 GistFile _$GistFileFromJson(Map<String, dynamic> json) => GistFile(
-      name: json['name'] as String?,
+      filename: json['filename'] as String?,
       size: json['size'] as int?,
       rawUrl: json['raw_url'] as String?,
       type: json['type'] as String?,
@@ -40,6 +55,16 @@ GistFile _$GistFileFromJson(Map<String, dynamic> json) => GistFile(
       truncated: json['truncated'] as bool?,
       content: json['content'] as String?,
     );
+
+Map<String, dynamic> _$GistFileToJson(GistFile instance) => <String, dynamic>{
+      'filename': instance.filename,
+      'size': instance.size,
+      'raw_url': instance.rawUrl,
+      'type': instance.type,
+      'language': instance.language,
+      'truncated': instance.truncated,
+      'content': instance.content,
+    };
 
 GistFork _$GistForkFromJson(Map<String, dynamic> json) => GistFork(
       user: json['user'] == null
@@ -54,6 +79,13 @@ GistFork _$GistForkFromJson(Map<String, dynamic> json) => GistFork(
           : DateTime.parse(json['updated_at'] as String),
     );
 
+Map<String, dynamic> _$GistForkToJson(GistFork instance) => <String, dynamic>{
+      'user': instance.user,
+      'id': instance.id,
+      'created_at': instance.createdAt?.toIso8601String(),
+      'updated_at': instance.updatedAt?.toIso8601String(),
+    };
+
 GistHistoryEntry _$GistHistoryEntryFromJson(Map<String, dynamic> json) =>
     GistHistoryEntry(
       version: json['version'] as String?,
@@ -67,6 +99,16 @@ GistHistoryEntry _$GistHistoryEntryFromJson(Map<String, dynamic> json) =>
           ? null
           : DateTime.parse(json['committed_at'] as String),
     );
+
+Map<String, dynamic> _$GistHistoryEntryToJson(GistHistoryEntry instance) =>
+    <String, dynamic>{
+      'version': instance.version,
+      'user': instance.user,
+      'change_status/deletions': instance.deletions,
+      'change_status/additions': instance.additions,
+      'change_status/total': instance.totalChanges,
+      'committed_at': instance.committedAt?.toIso8601String(),
+    };
 
 GistComment _$GistCommentFromJson(Map<String, dynamic> json) => GistComment(
       id: json['id'] as int?,

--- a/lib/src/common/model/misc.dart
+++ b/lib/src/common/model/misc.dart
@@ -3,7 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'misc.g.dart';
 
 /// Model class for a Gitignore Template.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class GitignoreTemplate {
   GitignoreTemplate({this.name, this.source});
 
@@ -15,6 +15,7 @@ class GitignoreTemplate {
 
   factory GitignoreTemplate.fromJson(Map<String, dynamic> input) =>
       _$GitignoreTemplateFromJson(input);
+  Map<String, dynamic> toJson() => _$GitignoreTemplateToJson(this);
 }
 
 /// Model class for GitHub Rate Limit Information.

--- a/lib/src/common/model/misc.g.dart
+++ b/lib/src/common/model/misc.g.dart
@@ -12,6 +12,12 @@ GitignoreTemplate _$GitignoreTemplateFromJson(Map<String, dynamic> json) =>
       source: json['source'] as String?,
     );
 
+Map<String, dynamic> _$GitignoreTemplateToJson(GitignoreTemplate instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'source': instance.source,
+    };
+
 RateLimit _$RateLimitFromJson(Map<String, dynamic> json) => RateLimit(
       json['limit'] as int?,
       json['remaining'] as int?,

--- a/lib/src/common/model/notifications.dart
+++ b/lib/src/common/model/notifications.dart
@@ -4,7 +4,7 @@ import 'package:json_annotation/json_annotation.dart';
 part 'notifications.g.dart';
 
 /// Model class for notifications.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Notification {
   Notification({
     this.id,
@@ -36,10 +36,11 @@ class Notification {
 
   factory Notification.fromJson(Map<String, dynamic> input) =>
       _$NotificationFromJson(input);
+  Map<String, dynamic> toJson() => _$NotificationToJson(this);
 }
 
 /// Model class for a notification subject.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class NotificationSubject {
   NotificationSubject({this.title, this.type, this.url, this.latestCommentUrl});
   final String? title;
@@ -51,4 +52,5 @@ class NotificationSubject {
 
   factory NotificationSubject.fromJson(Map<String, dynamic> input) =>
       _$NotificationSubjectFromJson(input);
+  Map<String, dynamic> toJson() => _$NotificationSubjectToJson(this);
 }

--- a/lib/src/common/model/notifications.g.dart
+++ b/lib/src/common/model/notifications.g.dart
@@ -27,6 +27,19 @@ Notification _$NotificationFromJson(Map<String, dynamic> json) => Notification(
       subscriptionUrl: json['subscription_url'] as String?,
     );
 
+Map<String, dynamic> _$NotificationToJson(Notification instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'repository': instance.repository,
+      'subject': instance.subject,
+      'reason': instance.reason,
+      'unread': instance.unread,
+      'updated_at': instance.updatedAt?.toIso8601String(),
+      'last_read_at': instance.lastReadAt?.toIso8601String(),
+      'url': instance.url,
+      'subscription_url': instance.subscriptionUrl,
+    };
+
 NotificationSubject _$NotificationSubjectFromJson(Map<String, dynamic> json) =>
     NotificationSubject(
       title: json['title'] as String?,
@@ -34,3 +47,12 @@ NotificationSubject _$NotificationSubjectFromJson(Map<String, dynamic> json) =>
       url: json['url'] as String?,
       latestCommentUrl: json['latest_comment_url'] as String?,
     );
+
+Map<String, dynamic> _$NotificationSubjectToJson(
+        NotificationSubject instance) =>
+    <String, dynamic>{
+      'title': instance.title,
+      'type': instance.type,
+      'url': instance.url,
+      'latest_comment_url': instance.latestCommentUrl,
+    };

--- a/lib/src/common/model/orgs.dart
+++ b/lib/src/common/model/orgs.dart
@@ -82,7 +82,7 @@ class Organization {
 }
 
 /// Model class for organization membership.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class OrganizationMembership {
   OrganizationMembership({
     this.state,
@@ -94,10 +94,11 @@ class OrganizationMembership {
   factory OrganizationMembership.fromJson(Map<String, dynamic> input) {
     return _$OrganizationMembershipFromJson(input);
   }
+  Map<String, dynamic> toJson() => _$OrganizationMembershipToJson(this);
 }
 
 /// Model class for a GitHub team.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Team {
   Team({
     this.name,
@@ -131,6 +132,7 @@ class Team {
   factory Team.fromJson(Map<String, dynamic> input) {
     return _$TeamFromJson(input);
   }
+  Map<String, dynamic> toJson() => _$TeamToJson(this);
 }
 
 /// Model class for the team membership state.
@@ -145,7 +147,7 @@ class TeamMembershipState {
 }
 
 /// Model class for a team member.
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class TeamMember {
   TeamMember(
       {this.login,
@@ -179,4 +181,5 @@ class TeamMember {
   factory TeamMember.fromJson(Map<String, dynamic> input) {
     return _$TeamMemberFromJson(input);
   }
+  Map<String, dynamic> toJson() => _$TeamMemberToJson(this);
 }

--- a/lib/src/common/model/orgs.g.dart
+++ b/lib/src/common/model/orgs.g.dart
@@ -56,6 +56,13 @@ OrganizationMembership _$OrganizationMembershipFromJson(
           : Organization.fromJson(json['organization'] as Map<String, dynamic>),
     );
 
+Map<String, dynamic> _$OrganizationMembershipToJson(
+        OrganizationMembership instance) =>
+    <String, dynamic>{
+      'state': instance.state,
+      'organization': instance.organization,
+    };
+
 Team _$TeamFromJson(Map<String, dynamic> json) => Team(
       name: json['name'] as String?,
       id: json['id'] as int?,
@@ -67,6 +74,15 @@ Team _$TeamFromJson(Map<String, dynamic> json) => Team(
           : Organization.fromJson(json['organization'] as Map<String, dynamic>),
     );
 
+Map<String, dynamic> _$TeamToJson(Team instance) => <String, dynamic>{
+      'name': instance.name,
+      'id': instance.id,
+      'permission': instance.permission,
+      'members_count': instance.membersCount,
+      'repos_count': instance.reposCount,
+      'organization': instance.organization,
+    };
+
 TeamMember _$TeamMemberFromJson(Map<String, dynamic> json) => TeamMember(
       login: json['login'] as String?,
       id: json['id'] as int?,
@@ -75,3 +91,13 @@ TeamMember _$TeamMemberFromJson(Map<String, dynamic> json) => TeamMember(
       siteAdmin: json['site_admin'] as bool?,
       htmlUrl: json['html_url'] as String?,
     );
+
+Map<String, dynamic> _$TeamMemberToJson(TeamMember instance) =>
+    <String, dynamic>{
+      'login': instance.login,
+      'id': instance.id,
+      'avatar_url': instance.avatarUrl,
+      'type': instance.type,
+      'site_admin': instance.siteAdmin,
+      'html_url': instance.htmlUrl,
+    };

--- a/lib/src/common/model/repos.dart
+++ b/lib/src/common/model/repos.dart
@@ -213,7 +213,7 @@ class Tag {
 
   factory Tag.fromJson(Map<String, dynamic> input) => _$TagFromJson(input);
   Map<String, dynamic> toJson() => _$TagToJson(this);
-  
+
   @override
   String toString() => 'Tag: $name';
 }

--- a/lib/src/common/model/repos.dart
+++ b/lib/src/common/model/repos.dart
@@ -3,9 +3,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'repos.g.dart';
 
-@JsonSerializable(
-  createToJson: false,
-)
+@JsonSerializable()
 class GitHubComparison {
   final String? url;
   final String? status;
@@ -19,6 +17,7 @@ class GitHubComparison {
 
   factory GitHubComparison.fromJson(Map<String, dynamic> json) =>
       _$GitHubComparisonFromJson(json);
+  Map<String, dynamic> toJson() => _$GitHubComparisonToJson(this);
 
   @override
   String toString() {
@@ -201,7 +200,7 @@ class RepositoryPermissions {
   Map<String, dynamic> toJson() => _$RepositoryPermissionsToJson(this);
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class Tag {
   final String name;
   final CommitInfo commit;
@@ -213,7 +212,8 @@ class Tag {
   Tag(this.name, this.commit, this.zipUrl, this.tarUrl);
 
   factory Tag.fromJson(Map<String, dynamic> input) => _$TagFromJson(input);
-
+  Map<String, dynamic> toJson() => _$TagToJson(this);
+  
   @override
   String toString() => 'Tag: $name';
 }

--- a/lib/src/common/model/repos.g.dart
+++ b/lib/src/common/model/repos.g.dart
@@ -18,6 +18,16 @@ GitHubComparison _$GitHubComparisonFromJson(Map<String, dynamic> json) =>
           .toList(),
     );
 
+Map<String, dynamic> _$GitHubComparisonToJson(GitHubComparison instance) =>
+    <String, dynamic>{
+      'url': instance.url,
+      'status': instance.status,
+      'ahead_by': instance.aheadBy,
+      'behind_by': instance.behindBy,
+      'total_commits': instance.totalCommits,
+      'files': instance.files,
+    };
+
 Repository _$RepositoryFromJson(Map<String, dynamic> json) => Repository(
       name: json['name'] as String? ?? '',
       id: json['id'] as int? ?? 0,
@@ -126,6 +136,13 @@ Tag _$TagFromJson(Map<String, dynamic> json) => Tag(
       json['zipball_url'] as String,
       json['tarball_url'] as String,
     );
+
+Map<String, dynamic> _$TagToJson(Tag instance) => <String, dynamic>{
+      'name': instance.name,
+      'commit': instance.commit,
+      'zipball_url': instance.zipUrl,
+      'tarball_url': instance.tarUrl,
+    };
 
 CommitData _$CommitDataFromJson(Map<String, dynamic> json) => CommitData(
       json['sha'] as String?,

--- a/lib/src/common/model/search.dart
+++ b/lib/src/common/model/search.dart
@@ -58,6 +58,7 @@ class CodeSearchItem {
     }
     return result;
   }
+
   Map<String, dynamic> toJson() => _$CodeSearchItemToJson(this);
 }
 

--- a/lib/src/common/model/search.dart
+++ b/lib/src/common/model/search.dart
@@ -9,7 +9,7 @@ abstract class SearchResults<T> {
   List<T>? items;
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class CodeSearchResults implements SearchResults<CodeSearchItem> {
   @JsonKey(name: 'total_count')
   @override
@@ -25,9 +25,10 @@ class CodeSearchResults implements SearchResults<CodeSearchItem> {
 
   static CodeSearchResults fromJson(Map<String, dynamic> input) =>
       _$CodeSearchResultsFromJson(input);
+  Map<String, dynamic> toJson() => _$CodeSearchResultsToJson(this);
 }
 
-@JsonSerializable(createToJson: false)
+@JsonSerializable()
 class CodeSearchItem {
   String? name;
   String? path;
@@ -57,11 +58,12 @@ class CodeSearchItem {
     }
     return result;
   }
+  Map<String, dynamic> toJson() => _$CodeSearchItemToJson(this);
 }
 
 // TODO: Issue Search
-// @JsonSerializable(createToJson: false)
+// @JsonSerializable()
 // class IssueSearchResults extends SearchResults<IssueSearchItem> {}
 
-// @JsonSerializable(createToJson: false)
+// @JsonSerializable()
 // class IssueSearchItem {}

--- a/lib/src/common/model/search.g.dart
+++ b/lib/src/common/model/search.g.dart
@@ -12,6 +12,13 @@ CodeSearchResults _$CodeSearchResultsFromJson(Map<String, dynamic> json) =>
       ..incompleteResults = json['incomplete_results'] as bool?
       ..items = CodeSearchItem.fromJsonList(json['items'] as List);
 
+Map<String, dynamic> _$CodeSearchResultsToJson(CodeSearchResults instance) =>
+    <String, dynamic>{
+      'total_count': instance.totalCount,
+      'incomplete_results': instance.incompleteResults,
+      'items': instance.items,
+    };
+
 CodeSearchItem _$CodeSearchItemFromJson(Map<String, dynamic> json) =>
     CodeSearchItem()
       ..name = json['name'] as String?
@@ -23,3 +30,14 @@ CodeSearchItem _$CodeSearchItemFromJson(Map<String, dynamic> json) =>
       ..repository = json['repository'] == null
           ? null
           : Repository.fromJson(json['repository'] as Map<String, dynamic>);
+
+Map<String, dynamic> _$CodeSearchItemToJson(CodeSearchItem instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'path': instance.path,
+      'sha': instance.sha,
+      'url': instance.url?.toString(),
+      'git_url': instance.gitUrl?.toString(),
+      'html_url': instance.htmlUrl?.toString(),
+      'repository': instance.repository,
+    };

--- a/lib/src/common/model/users.dart
+++ b/lib/src/common/model/users.dart
@@ -96,9 +96,7 @@ class User {
 
 /// The response from listing collaborators on a repo.
 // https://developer.github.com/v3/repos/collaborators/#response
-@JsonSerializable(
-  createToJson: false,
-)
+@JsonSerializable()
 class Collaborator {
   final String? login;
   final int? id;
@@ -118,6 +116,7 @@ class Collaborator {
 
   factory Collaborator.fromJson(Map<String, dynamic> json) =>
       _$CollaboratorFromJson(json);
+  Map<String, dynamic> toJson() => _$CollaboratorToJson(this);
 }
 
 /// The response from listing contributors on a repo.

--- a/lib/src/common/model/users.g.dart
+++ b/lib/src/common/model/users.g.dart
@@ -64,6 +64,16 @@ Collaborator _$CollaboratorFromJson(Map<String, dynamic> json) => Collaborator(
       ),
     );
 
+Map<String, dynamic> _$CollaboratorToJson(Collaborator instance) =>
+    <String, dynamic>{
+      'login': instance.login,
+      'id': instance.id,
+      'html_url': instance.htmlUrl,
+      'type': instance.type,
+      'site_admin': instance.siteAdmin,
+      'permissions': instance.permissions,
+    };
+
 Contributor _$ContributorFromJson(Map<String, dynamic> json) => Contributor(
       id: json['id'] as int?,
       login: json['login'] as String?,


### PR DESCRIPTION
Fixes #288 
The type of the files when getting a gist isn't a list, it is a map. This is a breaking change. So anywhere you were accessing the files from a gist before, you'll need to update your code to expect a map.

**Breaking change:** In the Gist class, the old type of files was
```dart
List<GistFile>? files;
```
and the new type is
```dart
Map<String, GistFile>? files;
```

**Breaking change:** In the GistFile class, the name property is now filename

While I was in there I noticed there were a lot of files that don't generate the toJson method. It doesn't hurt to generate those so I updated all the places that weren't generating toJson.