### PR TITLE
Add slug property to CheckRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.0.2
+- Add `slug` property in class `CheckRun`
+
+## 9.0.1
+- Add `conclusion` property in class `CheckRun`
+
 ## 9.0.0
 
 **Breaking change:** In the Gist class, the old type of files was
@@ -14,9 +20,6 @@ Map<String, GistFile>? files;
 * Fix getting gists by @robrbecker in https://github.com/SpinlockLabs/github.dart/pull/294
 
 **Full Changelog**: https://github.com/SpinlockLabs/github.dart/compare/8.5.0...9.0.0
-
-## 9.0.1
-- Add `conclusion` property in class `CheckRun`
 
 ## 8.5.0
 

--- a/lib/src/common/model/checks.dart
+++ b/lib/src/common/model/checks.dart
@@ -94,7 +94,7 @@ class CheckRun {
   final int? checkSuiteId;
   final String? detailsUrl;
   final DateTime startedAt;
-  final CheckRunConclusion conclusion;
+  final CheckRunConclusion? conclusion;
   final String? slug;
 
   const CheckRun._({

--- a/lib/src/common/model/checks.dart
+++ b/lib/src/common/model/checks.dart
@@ -95,6 +95,7 @@ class CheckRun {
   final String? detailsUrl;
   final DateTime startedAt;
   final CheckRunConclusion conclusion;
+  final String? slug;
 
   const CheckRun._({
     required this.id,
@@ -106,6 +107,7 @@ class CheckRun {
     required this.detailsUrl,
     required this.startedAt,
     required this.conclusion,
+    required this.slug,
   });
 
   factory CheckRun.fromJson(Map<String, dynamic> input) {
@@ -130,6 +132,7 @@ class CheckRun {
       detailsUrl: input['details_url'],
       startedAt: DateTime.parse(input['started_at']),
       conclusion: CheckRunConclusion._fromValue(input['conclusion']),
+      slug: input['app']['slug'],
     );
   }
 
@@ -146,6 +149,7 @@ class CheckRun {
       'details_url': detailsUrl,
       'started_at': startedAt.toIso8601String(),
       'conclusion': conclusion,
+      'slug': slug,
     };
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 9.0.1
+version: 9.0.2
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/test/unit/checks_test.dart
+++ b/test/unit/checks_test.dart
@@ -104,6 +104,7 @@ void main() {
       expect(checkRun.id, 4);
       expect(checkRun.name, 'mighty_readme');
       expect(checkRun.conclusion, CheckRunConclusion.neutral);
+      expect(checkRun.slug, 'octoapp');
     });
   });
 }


### PR DESCRIPTION
Added the slug property to be a member variable of checkRun class.
This is intended to help solve the https://github.com/flutter/flutter/issues/99805 issue. We can use the slug of the checkRun's app to distinguish whether this checkRun is cirrus-ci or flutter-dashboard.