### PR TITLE
Fix publish release workflow

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Publish
-        uses: sakebook/actions-flutter-pub-publisher@v1.3.1
+        uses: caseyhillers/actions-flutter-pub-publisher@v1.5.1
         with:
           credential: ${{ secrets.CREDENTIAL_JSON }}
           flutter_package: false


### PR DESCRIPTION
Temporarily moving this to a forked version of the action with the fix. When https://github.com/sakebook/actions-flutter-pub-publisher/pull/34 is merged, we can revert back to the upstream.