### PR TITLE
Simplify publish release action

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -17,4 +17,4 @@ jobs:
         mkdir -p ~/.pub-cache 
         echo ${{ secrets.CREDENTIAL_JSON }} > ~/.pub-cache/credentials.json
     - name: Publish package
-      run: pub publish -f
+      run: pub publish


### PR DESCRIPTION
The underlying release action fails as it copies the credentials.json into the source directory (pub will fail on secrets being detected)
