### PR TITLE
Add "head_branch" field to CheckSuite object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 9.8.0
+
+* Add "head_branch" field to CheckSuite object by @nehalvpatel in https://github.com/SpinlockLabs/github.dart/pull/347
+
+## New Contributors
+* @nehalvpatel made their first contribution in https://github.com/SpinlockLabs/github.dart/pull/347
+
+**Full Changelog**: https://github.com/SpinlockLabs/github.dart/compare/9.7.0...9.8.0
+
 ## 9.7.0
 * Add calendar versioning by @CaseyHillers in https://github.com/SpinlockLabs/github.dart/pull/338
 

--- a/lib/src/common/model/checks.dart
+++ b/lib/src/common/model/checks.dart
@@ -362,12 +362,14 @@ class CheckRunAction {
 @immutable
 class CheckSuite {
   final int? id;
+  final String? headBranch;
   final String? headSha;
   final CheckRunConclusion conclusion;
   final List<PullRequest> pullRequests;
 
   const CheckSuite({
     required this.conclusion,
+    required this.headBranch,
     required this.headSha,
     required this.id,
     required this.pullRequests,
@@ -381,6 +383,7 @@ class CheckSuite {
         .toList();
     return CheckSuite(
       conclusion: CheckRunConclusion._fromValue(input['conclusion']),
+      headBranch: input['head_branch'],
       headSha: input['head_sha'],
       id: input['id'],
       pullRequests: pullRequests,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: github
-version: 9.7.0
+version: 9.8.0
 description: A high-level GitHub API Client Library that uses Github's v3 API
 homepage: https://github.com/SpinlockLabs/github.dart
 

--- a/test/unit/checksuite_test.dart
+++ b/test/unit/checksuite_test.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+
+import 'package:github/src/common/model/checks.dart';
+import 'package:test/test.dart';
+
+/// The checkSuite Json is composed from multiple GitHub examples
+///
+/// See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+/// See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28
+const checkSuiteJson = '''{
+  "id": 5,
+  "head_branch": "main",
+  "head_sha": "d6fde92930d4715a2b49857d24b940956b26d2d3",
+  "conclusion": "neutral",
+  "pull_requests": [
+    {
+      "url": "https://api.github.com/repos/github/hello-world/pulls/1",
+      "id": 1934,
+      "number": 3956,
+      "head": {
+        "ref": "say-hello",
+        "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
+        "repo": {
+          "id": 526,
+          "url": "https://api.github.com/repos/github/hello-world",
+          "name": "hello-world"
+        }
+      },
+      "base": {
+        "ref": "master",
+        "sha": "e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f",
+        "repo": {
+          "id": 526,
+          "url": "https://api.github.com/repos/github/hello-world",
+          "name": "hello-world"
+        }
+      }
+    }
+  ]
+}''';
+
+const String expectedToString =
+    '{"name":"mighty_readme","id":4,"external_id":"","status":"completed","head_sha":"","check_suite":{"id":5},"details_url":"https://example.com","started_at":"2018-05-04T01:14:52.000Z","conclusion":"neutral"}';
+
+void main() {
+  group('Check suite', () {
+    test('CheckSuite fromJson', () {
+      final checkSuite = CheckSuite.fromJson(jsonDecode(checkSuiteJson));
+
+      expect(checkSuite.id, 5);
+      expect(checkSuite.headBranch, 'main');
+      expect(checkSuite.headSha, 'd6fde92930d4715a2b49857d24b940956b26d2d3');
+      expect(checkSuite.conclusion, CheckRunConclusion.neutral);
+    });
+
+    test('CheckSuite fromJson for skipped conclusion', () {
+      /// The checkSuite Json is composed from multiple GitHub examples
+      ///
+      /// See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+      /// See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28
+      const checkSuiteJson = '''{
+        "id": 10,
+        "head_branch": "master",
+        "head_sha": "ce587453ced02b1526dfb4cb910479d431683101",
+        "conclusion": "skipped",
+        "pull_requests": [
+          {
+            "url": "https://api.github.com/repos/github/hello-world/pulls/1",
+            "id": 1934,
+            "number": 3956,
+            "head": {
+              "ref": "say-hello",
+              "sha": "3dca65fa3e8d4b3da3f3d056c59aee1c50f41390",
+              "repo": {
+                "id": 526,
+                "url": "https://api.github.com/repos/github/hello-world",
+                "name": "hello-world"
+              }
+            },
+            "base": {
+              "ref": "master",
+              "sha": "e7fdf7640066d71ad16a86fbcbb9c6a10a18af4f",
+              "repo": {
+                "id": 526,
+                "url": "https://api.github.com/repos/github/hello-world",
+                "name": "hello-world"
+              }
+            }
+          }
+        ]
+      }''';
+      final checkSuite = CheckSuite.fromJson(jsonDecode(checkSuiteJson));
+
+      expect(checkSuite.id, 10);
+      expect(checkSuite.headBranch, 'master');
+      expect(checkSuite.headSha, 'ce587453ced02b1526dfb4cb910479d431683101');
+      expect(checkSuite.conclusion, CheckRunConclusion.skipped);
+    });
+  });
+}

--- a/test/unit/checksuite_test.dart
+++ b/test/unit/checksuite_test.dart
@@ -51,6 +51,7 @@ void main() {
       expect(checkSuite.headBranch, 'main');
       expect(checkSuite.headSha, 'd6fde92930d4715a2b49857d24b940956b26d2d3');
       expect(checkSuite.conclusion, CheckRunConclusion.neutral);
+      expect(checkSuite.pullRequests.isNotEmpty, true);
     });
 
     test('CheckSuite fromJson for skipped conclusion', () {
@@ -95,6 +96,26 @@ void main() {
       expect(checkSuite.headBranch, 'master');
       expect(checkSuite.headSha, 'ce587453ced02b1526dfb4cb910479d431683101');
       expect(checkSuite.conclusion, CheckRunConclusion.skipped);
+      expect(checkSuite.pullRequests.isNotEmpty, true);
+    });
+
+    test('CheckSuite fromJson for forked repository', () {
+      /// The checkSuite Json is composed from multiple GitHub examples
+      ///
+      /// See https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+      /// See https://docs.github.com/en/rest/checks/suites?apiVersion=2022-11-28
+      const checkSuiteJson = '''{
+        "id": 10,
+        "head_branch": null,
+        "head_sha": "ce587453ced02b1526dfb4cb910479d431683101",
+        "conclusion": "skipped",
+        "pull_requests": []
+      }''';
+      final checkSuite = CheckSuite.fromJson(jsonDecode(checkSuiteJson));
+
+      expect(checkSuite.id, 10);
+      expect(checkSuite.headBranch, null);
+      expect(checkSuite.pullRequests.isEmpty, true);
     });
   });
 }


### PR DESCRIPTION
This field is part of the "check_suite" object as seen here: https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=rerequested#check_run

Although the `head_sha` usually provides enough information, it is useful to know which branch was targeted when the checkrun was rerequested.

<details>
  <summary>Image</summary>
  <img width="670" alt="Screenshot 2023-01-17 at 3 51 33 PM" src="https://user-images.githubusercontent.com/159021/213037561-5a9fdc42-49b5-429f-9712-1a048a0ed66b.png">
</details>