### PR TITLE
Make `User` field nullable in `PullRequestReview`

### DIFF
--- a/lib/src/common/model/pulls.dart
+++ b/lib/src/common/model/pulls.dart
@@ -311,14 +311,14 @@ class PullRequestFile {
 class PullRequestReview {
   PullRequestReview(
       {required this.id,
-      required this.user,
+      this.user,
       this.body,
       this.state,
       this.htmlUrl,
       this.pullRequestUrl});
 
   int id;
-  User user;
+  User? user;
   String? body;
   String? state;
   String? htmlUrl;

--- a/lib/src/common/model/pulls.g.dart
+++ b/lib/src/common/model/pulls.g.dart
@@ -253,7 +253,9 @@ Map<String, dynamic> _$PullRequestFileToJson(PullRequestFile instance) =>
 PullRequestReview _$PullRequestReviewFromJson(Map<String, dynamic> json) =>
     PullRequestReview(
       id: json['id'] as int,
-      user: User.fromJson(json['user'] as Map<String, dynamic>),
+      user: json['user'] == null
+          ? null
+          : User.fromJson(json['user'] as Map<String, dynamic>),
       body: json['body'] as String?,
       state: json['state'] as String?,
       htmlUrl: json['html_url'] as String?,


### PR DESCRIPTION
As the response can contain a `null` user if it was deleted and now is `Ghost`, see 
```bash
curl -L https://api.github.com/repos/dart-lang/http2/pulls/83/reviews
```