### PR TITLE
Handle 'null' conclusion

### DIFF
--- a/lib/src/common/model/checks.dart
+++ b/lib/src/common/model/checks.dart
@@ -54,7 +54,7 @@ class CheckRunConclusion extends EnumWithValue {
   const CheckRunConclusion._(super.value);
 
   factory CheckRunConclusion._fromValue(String? value) {
-    if (value == null) {
+    if (value == null || value == 'null') {
       return empty;
     }
     for (final level in const [

--- a/test/unit/checks_test.dart
+++ b/test/unit/checks_test.dart
@@ -100,6 +100,9 @@ const checkRunJson = '''{
 const String expectedToString =
     '{"name":"mighty_readme","id":4,"external_id":"","status":"completed","head_sha":"","check_suite":{"id":5},"details_url":"https://example.com","started_at":"2018-05-04T01:14:52.000Z","conclusion":"neutral"}';
 
+const String newCheckRun =
+    '{"name":"New CheckRun","id":12345,"external_id":"","status":"queued","head_sha":"","check_suite":{"id":123456},"details_url":"https://example.com","started_at":"2024-12-05T01:05:24.000Z","conclusion":"null"}';
+
 void main() {
   group('Check run', () {
     test('CheckRun fromJson', () {
@@ -108,6 +111,14 @@ void main() {
       expect(checkRun.id, 4);
       expect(checkRun.name, 'mighty_readme');
       expect(checkRun.conclusion, CheckRunConclusion.neutral);
+    });
+
+    test('CheckRun from freshly created and encoded', () {
+      final checkRun = CheckRun.fromJson(jsonDecode(newCheckRun));
+
+      expect(checkRun.id, 12345);
+      expect(checkRun.name, 'New CheckRun');
+      expect(checkRun.conclusion, CheckRunConclusion.empty);
     });
 
     test('CheckRun fromJson for skipped conclusion', () {


### PR DESCRIPTION
Creating a new concolusion with the GitHub API and then encoding that CheckRun to json adds: `"conclusion":"null"` to the json string; attempting to decode that throws an exception.

Fixes #412